### PR TITLE
feat: Elevated Rate Limits core mechanism 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Buckets:
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
-- `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take. 
+- `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take.
+- `elevated_limits` (object): elevated limits configuration that kick in when the bucket is empty. Consider it overrides that kick in when the bucket is empty.
 
 Ping:
 
@@ -127,13 +128,14 @@ limitd.take(type, key, [count], (err, result) => {
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
-
+-  `erlIsActiveKey`: the identifier of the ERL activation for the bucket. Must be passed for buckets that have ERL configured.
 The result object has:
 
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.
 -  `remaining` (int): the amount of remaining tokens in the bucket.
 -  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.
 -  `limit` (int): the size of the bucket.
+-  `erl_activated` (boolean): true if the bucket has ERL activated at the time of the request. Only returned for buckets that have ERL configured.
 
 ## PUT
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ overrides: {
 
 ## ERL (Elevated Rate Limits)
 ERL is a feature that allows you to define a different set of limits that kick in when the bucket is empty.
+To be able to allow its use within limitd-redis, you need to set the `allowERL` to `true`
 You can configure elevated limits inside your type definitions as follows:
 
 ```js
@@ -147,9 +148,10 @@ limitd.take(type, key, [count], (err, result) => {
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
--  `erlIsActiveKey`: the identifier of the ERL activation for the bucket. Must be passed for buckets that have ERL configured.
-The result object has:
+-  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket. Must be passed for buckets that have ERL configured.
+-  `allowERL`: (boolean = false) if set to true, the ERL feature will be allowed to be used. Default is false.
 
+The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.
 -  `remaining` (int): the amount of remaining tokens in the bucket.
 -  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Buckets:
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
 - `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take.
-- `elevated_limits` (object): elevated limits configuration that kick in when the bucket is empty. Consider it overrides that kick in when the bucket is empty.
+- `elevated_limits` (object): elevated limits configuration that kick in when the bucket is empty. Consider it as an override that kick in when the bucket is empty.
 
 Ping:
 
@@ -67,6 +67,7 @@ If you omit `size`, limitdb assumes that `size` is the value of `per_interval`. 
 
 If you don't specify a filling rate with `per_interval` or any other `per_x`, the bucket is fixed and you have to manually reset it using `PUT`.
 
+## Overrides
 You can also define `overrides` inside your type definitions as follows:
 
 ```js
@@ -106,6 +107,24 @@ overrides: {
     size:       100,
     per_second: 50,
     until:      new Date(2016, 4, 1)
+  }
+}
+```
+
+## ERL (Elevated Rate Limits)
+ERL is a feature that allows you to define a different set of limits that kick in when the bucket is empty.
+You can configure elevated limits inside your type definitions as follows:
+
+```js
+buckets = {
+  ip: {
+    size: 10,
+    per_second: 5,
+    elevated_limits: {
+      size: 100, // new bucket size. already used tokens will be deducted from current bucket content upon ERL activation.
+      per_second: 50, // new bucket refill ate
+      erl_activation_period_mins: 5, // for how long the ERL configuration should remain active
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ buckets = {
 ## TAKE
 
 ```js
-limitd.take(type, key, [count], erlActiveKey, allowERL (err, result) => {
+limitd.take(type, key, { count, configOverride, erlIsActive, allowERL}, (err, result) => {
   console.log(result);
 });
 ```
@@ -156,7 +156,7 @@ limitd.take(type, key, [count], erlActiveKey, allowERL (err, result) => {
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
--  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket. Must be passed for buckets that have ERL configured.
+-  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket. Only mandatory to pass while operating on buckets that have ERL configured.
 -  `allowERL`: (boolean) optional. if set to true, the ERL feature will be allowed to be used.
 
 The result object has:

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,6 +10,7 @@ const DBPing = require("./db_ping");
 const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, "utf8");
+const TAKE_ELEVATED_LUA = fs.readFileSync(`${__dirname}/take_elevated.lua`, "utf8");
 const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, "utf8");
 
 const PING_SUCCESS = "successful";
@@ -89,6 +90,11 @@ class LimitDBRedis extends EventEmitter {
     this.redis.defineCommand('take', {
       numberOfKeys: 1,
       lua: TAKE_LUA
+    });
+
+    this.redis.defineCommand('takeElevated', {
+      numberOfKeys: 2,
+      lua: TAKE_ELEVATED_LUA
     });
 
     this.redis.defineCommand('put', {
@@ -200,6 +206,7 @@ class LimitDBRedis extends EventEmitter {
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     const key = `${params.type}:${params.key}`;
+    const erlIsActiveKey = params.erlIsActiveKey; // redis' way of knowing whether erl is active or not
 
     let count = this._determineCount({
       paramsCount: params.count,
@@ -239,39 +246,71 @@ class LimitDBRedis extends EventEmitter {
           count *= (bucketKeyConfig.skip_n_calls + 1);
         }
       }
-
-
     }
 
-    this.redis.take(key,
-      bucketKeyConfig.ms_per_interval || 0,
-      bucketKeyConfig.size,
-      count,
-      Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
-      bucketKeyConfig.drip_interval || 0,
-      (err, results) => {
-        if (err) {
-          return callback(err);
-        }
-
-        const remaining = parseInt(results[0], 10);
-        const conformant = parseInt(results[1], 10) ? true : false;
-        const currentMS = parseInt(results[2], 10);
-        const reset = parseInt(results[3], 10);
-        const res = {
-          conformant,
-          remaining,
-          reset: Math.ceil(reset / 1000),
-          limit: bucketKeyConfig.size,
-          delayed: false,
-        };
-
-        if (bucketKeyConfig.skip_n_calls > 0) {
-          this.callCounts.set(key, { res, count: 0 });
-        }
-
-        return callback(null, res);
-      });
+    if (bucket.elevated_limits) {
+      if (!erlIsActiveKey)  {
+        return callback(new Error('erlIsActiveKey is required for elevated limits'), null);
+      }
+      this.redis.takeElevated(key, erlIsActiveKey,
+          bucketKeyConfig.ms_per_interval || 0,
+          bucketKeyConfig.size,
+          count,
+          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+          bucketKeyConfig.drip_interval || 0,
+          bucketKeyConfig.elevated_limits.ms_per_interval || 0,
+          bucketKeyConfig.elevated_limits.size,
+          bucketKeyConfig.elevated_limits.activation_period_minutes || 15,
+          (err, results) => {
+            if (err) {
+              return callback(err);
+            }
+            const remaining = parseInt(results[0], 10);
+            const conformant = parseInt(results[1], 10) ? true : false;
+            const currentMS = parseInt(results[2], 10);
+            const reset = parseInt(results[3], 10);
+            const erl_activated = parseInt(results[4], 10) ? true : false;
+            const res = {
+              conformant,
+              remaining,
+              reset: Math.ceil(reset / 1000),
+              limit: bucketKeyConfig.size,
+              delayed: false,
+              erl_activated,
+            };
+            if (bucketKeyConfig.skip_n_calls > 0) {
+              this.callCounts.set(key, { res, count: 0 });
+            }
+            return callback(null, res);
+          });
+    } else {
+      this.redis.take(key,
+          bucketKeyConfig.ms_per_interval || 0,
+          bucketKeyConfig.size,
+          count,
+          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+          bucketKeyConfig.drip_interval || 0,
+          (err, results) => {
+            if (err) {
+              return callback(err);
+            }
+            const remaining = parseInt(results[0], 10);
+            const conformant = parseInt(results[1], 10) ? true : false;
+            const currentMS = parseInt(results[2], 10);
+            const reset = parseInt(results[3], 10);
+            const res = {
+              conformant,
+              remaining,
+              reset: Math.ceil(reset / 1000),
+              limit: bucketKeyConfig.size,
+              delayed: false,
+            };
+            if (bucketKeyConfig.skip_n_calls > 0) {
+              this.callCounts.set(key, { res, count: 0 });
+            }
+            return callback(null, res);
+          });
+    }
   }
 
   /**

--- a/lib/db.js
+++ b/lib/db.js
@@ -260,7 +260,7 @@ class LimitDBRedis extends EventEmitter {
           bucketKeyConfig.drip_interval || 0,
           bucketKeyConfig.elevated_limits.ms_per_interval || 0,
           bucketKeyConfig.elevated_limits.size,
-          bucketKeyConfig.elevated_limits.activation_period_minutes || 15,
+          bucketKeyConfig.elevated_limits.erl_activation_period_mins,
           (err, results) => {
             if (err) {
               return callback(err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -248,7 +248,7 @@ class LimitDBRedis extends EventEmitter {
       }
     }
 
-    if (bucket.elevated_limits) {
+    if (bucket.elevated_limits && params.allowERL===true) {
       if (!erlIsActiveKey)  {
         return callback(new Error('erlIsActiveKey is required for elevated limits'), null);
       }

--- a/lib/db.js
+++ b/lib/db.js
@@ -248,7 +248,7 @@ class LimitDBRedis extends EventEmitter {
       }
     }
 
-    if (bucket.elevated_limits && params.allowERL===true) {
+    if (bucket.elevated_limits && params.allowERL === true) {
       if (!erlIsActiveKey)  {
         return callback(new Error('erlIsActiveKey is required for elevated limits'), null);
       }

--- a/lib/db.js
+++ b/lib/db.js
@@ -260,7 +260,7 @@ class LimitDBRedis extends EventEmitter {
           bucketKeyConfig.drip_interval || 0,
           bucketKeyConfig.elevated_limits.ms_per_interval || 0,
           bucketKeyConfig.elevated_limits.size,
-          bucketKeyConfig.elevated_limits.erl_activation_period_mins,
+          bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
           (err, results) => {
             if (err) {
               return callback(err);

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -41,6 +41,9 @@ end
 local new_content = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
 local enough_tokens = new_content >= tokens_to_take
 
+-- https://redis.io/docs/interact/programmability/eval-intro/#:~:text=scripts%20debugger.-,Script%20replication,-In%20standalone%20deployments
+redis.replicate_commands()
+
 if enough_tokens and is_erl_activated==0 then
     new_content = math.min(new_content - tokens_to_take, bucket_size)
 else
@@ -61,8 +64,7 @@ else
     end
 end
 
--- https://redis.io/commands/EVAL#replicating-commands-instead-of-scripts
-redis.replicate_commands()
+
 
 redis.call('HMSET', KEYS[1],
             'd', current_timestamp_ms,

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -1,0 +1,77 @@
+local tokens_per_ms               = tonumber(ARGV[1])
+local bucket_size                 = tonumber(ARGV[2])
+local tokens_to_take              = tonumber(ARGV[3])
+local ttl                         = tonumber(ARGV[4])
+local drip_interval               = tonumber(ARGV[5])
+local erl_tokens_per_ms           = tonumber(ARGV[6])
+local erl_bucket_size             = tonumber(ARGV[7])
+local erl_activation_period_mins  = tonumber(ARGV[8])
+
+-- check if we should use erl
+local erlKey = KEYS[2]
+local is_erl_activated = redis.call('EXISTS', erlKey)
+
+local current_time = redis.call('TIME')
+local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
+
+local current = redis.pcall('HMGET', KEYS[1], 'd', 'r')
+
+if current.err ~= nil then
+    current = {}
+end
+
+
+local function calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
+    if current[1] and tokens_per_ms then
+        -- drip bucket
+        local last_drip = current[1]
+        local content = current[2]
+        local delta_ms = math.max(current_timestamp_ms - last_drip, 0)
+        local drip_amount = delta_ms * tokens_per_ms
+        return math.min(content + drip_amount, bucket_size)
+    elseif current[1] and tokens_per_ms == 0 then
+        -- fixed bucket
+        return current[2]
+    else
+        -- first take of the bucket
+        return bucket_size
+    end
+end
+
+local new_content = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
+local enough_tokens = new_content >= tokens_to_take
+
+if enough_tokens and is_erl_activated==0 then
+    new_content = math.min(new_content - tokens_to_take, bucket_size)
+else
+    -- use erl
+    new_content = calculateNewBucketContent(current, erl_tokens_per_ms, erl_bucket_size, current_timestamp_ms)
+
+    -- if activating erl for first time, refill the bucket with the old bucket size
+    if is_erl_activated == 0 then
+        new_content = erl_bucket_size - bucket_size
+        redis.call('SET', erlKey, '1')
+        redis.call('EXPIRE', erlKey, erl_activation_period_mins * 60)
+        is_erl_activated = 1 -- this will be returned to the caller, so we should set it
+    end
+
+    enough_tokens = new_content >= tokens_to_take
+    if enough_tokens then
+        new_content = math.min(new_content - tokens_to_take, erl_bucket_size)
+    end
+end
+
+-- https://redis.io/commands/EVAL#replicating-commands-instead-of-scripts
+redis.replicate_commands()
+
+redis.call('HMSET', KEYS[1],
+            'd', current_timestamp_ms,
+            'r', new_content)
+redis.call('EXPIRE', KEYS[1], ttl)
+
+local reset_ms = 0
+if drip_interval > 0 then
+    reset_ms = math.ceil(current_timestamp_ms + (bucket_size - new_content) * drip_interval)
+end
+
+return { new_content, enough_tokens, current_timestamp_ms, reset_ms, is_erl_activated }

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -7,19 +7,22 @@ local erl_tokens_per_ms           = tonumber(ARGV[6])
 local erl_bucket_size             = tonumber(ARGV[7])
 local erl_activation_period_mins  = tonumber(ARGV[8])
 
--- check if we should use erl
+-- the key to use for pulling last bucket state from redis
+local lastBucketStateKey = KEYS[1]
+
+-- the key for checking in redis if elevated rate limits (erl) were activated earlier
 local erlKey = KEYS[2]
 local is_erl_activated = redis.call('EXISTS', erlKey)
 
-local current_time = redis.call('TIME')
-local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
-
-local current = redis.pcall('HMGET', KEYS[1], 'd', 'r')
-
+-- get current bucket state
+local current = redis.pcall('HMGET', lastBucketStateKey, 'd', 'r')
 if current.err ~= nil then
     current = {}
 end
 
+-- get current time from redis, to be used in new bucket size calculations later
+local current_time = redis.call('TIME')
+local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
 
 local function calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
     if current[1] and tokens_per_ms then
@@ -38,38 +41,38 @@ local function calculateNewBucketContent(current, tokens_per_ms, bucket_size, cu
     end
 end
 
-local new_content = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
-local enough_tokens = new_content >= tokens_to_take
-
+-- Enable verbatim replication to ensure redis sends script's source code to all masters
+-- managing the sharded database in a clustered deployment.
 -- https://redis.io/docs/interact/programmability/eval-intro/#:~:text=scripts%20debugger.-,Script%20replication,-In%20standalone%20deployments
 redis.replicate_commands()
 
-if enough_tokens and is_erl_activated == 0 then
+-- calculate new bucket content
+local new_content = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
+local enough_tokens = new_content >= tokens_to_take
+if enough_tokens and is_erl_activated==0 then
     new_content = math.min(new_content - tokens_to_take, bucket_size)
 else
-    -- use erl
+    -- calculate new bucket content based on elevated rate limits
     new_content = calculateNewBucketContent(current, erl_tokens_per_ms, erl_bucket_size, current_timestamp_ms)
-
     -- if activating erl for first time, refill the bucket with the old bucket size
     if is_erl_activated == 0 then
         new_content = erl_bucket_size - bucket_size
+        -- save erl state
         redis.call('SET', erlKey, '1')
         redis.call('EXPIRE', erlKey, erl_activation_period_mins * 60)
         is_erl_activated = 1 -- this will be returned to the caller, so we should set it
     end
-
     enough_tokens = new_content >= tokens_to_take
     if enough_tokens then
         new_content = math.min(new_content - tokens_to_take, erl_bucket_size)
     end
 end
 
-
-
-redis.call('HMSET', KEYS[1],
+-- save bucket state
+redis.call('HMSET', lastBucketStateKey,
             'd', current_timestamp_ms,
             'r', new_content)
-redis.call('EXPIRE', KEYS[1], ttl)
+redis.call('EXPIRE', lastBucketStateKey, ttl)
 
 local reset_ms = 0
 if drip_interval > 0 then

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -44,7 +44,7 @@ local enough_tokens = new_content >= tokens_to_take
 -- https://redis.io/docs/interact/programmability/eval-intro/#:~:text=scripts%20debugger.-,Script%20replication,-In%20standalone%20deployments
 redis.replicate_commands()
 
-if enough_tokens and is_erl_activated==0 then
+if enough_tokens and is_erl_activated == 0 then
     new_content = math.min(new_content - tokens_to_take, bucket_size)
 else
     -- use erl

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -5,7 +5,7 @@ local ttl                         = tonumber(ARGV[4])
 local drip_interval               = tonumber(ARGV[5])
 local erl_tokens_per_ms           = tonumber(ARGV[6])
 local erl_bucket_size             = tonumber(ARGV[7])
-local erl_activation_period_mins  = tonumber(ARGV[8])
+local erl_activation_period_seconds  = tonumber(ARGV[8])
 
 -- the key to use for pulling last bucket state from redis
 local lastBucketStateKey = KEYS[1]
@@ -74,7 +74,7 @@ else
             bucket_content_after_take = math.min(bucket_content_after_erl_activation - tokens_to_take, erl_bucket_size)
             -- save erl state
             redis.call('SET', erlKey, '1')
-            redis.call('EXPIRE', erlKey, erl_activation_period_mins * 60)
+            redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
             is_erl_activated = 1
         end
     end

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,8 @@ function normalizeTemporals(params) {
     'interval',
     'size',
     'unlimited',
-    'skip_n_calls'
+    'skip_n_calls',
+    'activation_period_minutes'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
@@ -41,6 +42,9 @@ function normalizeTemporals(params) {
 
 function normalizeType(params) {
   const type = normalizeTemporals(params);
+  if (params.elevated_limits) {
+    type.elevated_limits = normalizeTemporals(params.elevated_limits);
+  }
 
   type.overridesMatch = {};
   type.overrides = _.reduce(params.overrides || params.override, (result, overrideDef, name) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,7 @@ const INTERVAL_TO_MS = {
 };
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
-const ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES = 15;
+const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -19,7 +19,7 @@ function normalizeTemporals(params) {
     'size',
     'unlimited',
     'skip_n_calls',
-    'erl_activation_period_mins'
+    'erl_activation_period_seconds'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
@@ -41,8 +41,8 @@ function normalizeTemporals(params) {
   if (params.elevated_limits) {
     type.elevated_limits = normalizeTemporals(params.elevated_limits);
   }
-  if (!type.erl_activation_period_mins) {
-    type.erl_activation_period_mins = ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES;
+  if (!type.erl_activation_period_seconds) {
+    type.erl_activation_period_seconds = ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS;
   }
 
   return type;
@@ -125,5 +125,5 @@ module.exports = {
   normalizeType,
   functionOrFalse,
   randomBetween,
-  ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES,
+  ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,7 @@ const INTERVAL_TO_MS = {
 };
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
+const ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES = 15;
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -18,7 +19,7 @@ function normalizeTemporals(params) {
     'size',
     'unlimited',
     'skip_n_calls',
-    'activation_period_minutes'
+    'erl_activation_period_mins'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
@@ -35,6 +36,11 @@ function normalizeTemporals(params) {
     type.ttl = ((type.size * type.interval) / type.per_interval) / 1000;
     type.ms_per_interval = type.per_interval / type.interval;
     type.drip_interval = type.interval / type.per_interval;
+  }
+
+  // if erl_activation_period_mins is not set, use the default value
+  if (!type.erl_activation_period_mins) {
+    type.erl_activation_period_mins = ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES;
   }
 
   return type;
@@ -116,5 +122,6 @@ module.exports = {
   normalizeTemporals,
   normalizeType,
   functionOrFalse,
-  randomBetween
+  randomBetween,
+  ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,5 +123,5 @@ module.exports = {
   normalizeType,
   functionOrFalse,
   randomBetween,
-  ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES
+  ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,9 @@ function normalizeTemporals(params) {
     type.drip_interval = type.interval / type.per_interval;
   }
 
-  // if erl_activation_period_mins is not set, use the default value
+  if (params.elevated_limits) {
+    type.elevated_limits = normalizeTemporals(params.elevated_limits);
+  }
   if (!type.erl_activation_period_mins) {
     type.erl_activation_period_mins = ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES;
   }

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -6,6 +6,7 @@ const LimitDB  = require('../lib/db');
 const assert   = require('chai').assert;
 const {Toxiproxy, Toxic} = require('toxiproxy-node-client');
 const crypto  = require('crypto')
+const {ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES} = require("../lib/utils");
 
 const buckets = {
   ip: {
@@ -866,7 +867,7 @@ describe('LimitDBRedis', () => {
               erlIsActiveKey: 'some_erl_active_identifier'
             }))
             .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-              assert.equal(ttl, 900); // 15 minutes in seconds
+              assert.equal(ttl, 60*ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES); // 15 minutes in seconds
               done()
             }))
       });
@@ -878,7 +879,7 @@ describe('LimitDBRedis', () => {
           elevated_limits: {
             size: 10,
             per_minute: 1,
-            activation_period_minutes: 20,
+            erl_activation_period_mins: 20,
           }
         });
         takeElevatedPromise({type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier'})

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -691,236 +691,236 @@ describe('LimitDBRedis', () => {
           resolve(isActive);
         });
       })
-
-      it('should set a key at erlIsActiveKey when erl is activated for a bucket with elevated_limits configuration', async () => {
-        const bucketName = 'bucket_with_elevated_limits_config';
-        const erlIsActiveKey = 'some_erl_active_identifier';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 2,
-            per_minute: 2,
-          },
-        })
-
-        // erl not activated yet
-        await takeElevatedPromise({type: bucketName, key: 'some_key', erlIsActiveKey})
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
-
-        // erl now activated
-        await takeElevatedPromise({type: bucketName, key: 'some_key', erlIsActiveKey})
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1))
-      });
-      it('should raise an error if erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
-        const bucketName = 'bucket_with_elevated_limits_config';
-        const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined};
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 2,
-            per_minute: 2,
-          },
-        })
-
-        db.take(params, (err) => {
-          assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
-          done();
-        });
-      });
-      it('should rate limit according to default configuration if there is no erl configuration, regardless of erlIsActiveKey', async () => {
-        const bucketName = 'bucket_without_erl_config';
-        db.configurateBucket(bucketName, {
-          size: 2,
-          per_minute: 1,
-        })
-
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: "some-key"
-        }).then((result) => {
-          assert.isTrue(result.conformant);
-          assert.notExists(result.erl_activated);
-        });
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: undefined
-        }).then((result) => {
-          assert.isTrue(result.conformant);
-          assert.notExists(result.erl_activated);
-        });
-      });
-      it('should apply erl limits if normal rate limits are exceeded', async () => {
-        const bucketName = 'bucket_with_elevated_limits_config';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 10,
-            per_minute: 2,
-          },
-        })
-
-        // first call, still within normal rate limits
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isFalse(result.erl_activated);
-        })
-        // second call, normal rate limits exceeded and erl is activated
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isTrue(result.erl_activated);
-          assert.isTrue(result.conformant);
-          assert.equal(result.remaining, 8)
-        })
-
-      });
-      it('should rate limit if both normal and erl rate limit are exceeded', async () => {
-        const bucketName = 'bucket_with_elevated_limits_config';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 2,
-            per_minute: 2,
-          },
-        })
-
-        // first call, still within normal rate limits
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isTrue(result.conformant);
-          assert.isFalse(result.erl_activated);
-          assert.equal(result.remaining, 0)
-        })
-        // second call, normal rate limits exceeded and erl is activated.
-        // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isTrue(result.conformant);
-          assert.isTrue(result.erl_activated);
-          assert.equal(result.remaining, 0);
-        })
-        // third call, erl rate limit exceeded
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_bucket_key',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isFalse(result.conformant); // being rate limited
-          assert.isTrue(result.erl_activated);
-          assert.equal(result.remaining, 0);
-        })
-      });
-      it('should deduct already used tokens from new bucket when erl is activated', async () => {
-        const bucketName = 'test-bucket';
-        await db.configurateBucket(bucketName, {
-          size: 2,
-          per_minute: 1,
-          elevated_limits: {
-            size: 10,
+      describe('when allowERL is true', () => {
+        it('should set a key at erlIsActiveKey when erl is activated for a bucket with elevated_limits configuration', async () => {
+          const bucketName = 'bucket_with_elevated_limits_config';
+          const erlIsActiveKey = 'some_erl_active_identifier';
+          db.configurateBucket(bucketName, {
+            size: 1,
             per_minute: 1,
-          }
-        });
+            elevated_limits: {
+              size: 2,
+              per_minute: 2,
+            },
+          })
+          const params ={type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:true}
 
-        await takeElevatedPromise({type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier'})
-        await takeElevatedPromise({type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier'})
-        await takeElevatedPromise({
-          type: bucketName,
-          key: 'some_key ',
-          erlIsActiveKey: 'some_erl_active_identifier'
-        }).then((result) => {
-          assert.isTrue(result.conformant);
-          assert.isTrue(result.erl_activated);
-          assert.equal(result.remaining, 7); // Total used tokens so far: 3
+          // erl not activated yet
+          await takeElevatedPromise(params)
+          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
+
+          // erl now activated
+          await takeElevatedPromise(params)
+          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1))
         });
-      })
-      it('should use default ttl if erl activation period is not configured', (done) => {
-        const bucketName = 'test-bucket';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 10,
+        it('should raise an error if erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
+          const bucketName = 'bucket_with_elevated_limits_config';
+          const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined, allowERL:true};
+          db.configurateBucket(bucketName, {
+            size: 1,
             per_minute: 1,
-          }
+            elevated_limits: {
+              size: 2,
+              per_minute: 2,
+            },
+          })
+
+          db.take(params, (err) => {
+            assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
+            done();
+          });
         });
-        takeElevatedPromise({type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier'})
-            .then(() => takeElevatedPromise({
-              type: bucketName,
-              key: 'some_key',
-              erlIsActiveKey: 'some_erl_active_identifier'
-            }))
-            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-              assert.equal(ttl, 60*ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES); // 15 minutes in seconds
-              done()
-            }))
-      });
-      it('should use ttl calculated using erl activation period if erl activation period is configured', (done) => {
-        const bucketName = 'test-bucket';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 10,
+        it('should rate limit according to default configuration if there is no erl configuration, regardless of erlIsActiveKey', async () => {
+          const bucketName = 'bucket_without_erl_config';
+          db.configurateBucket(bucketName, {
+            size: 2,
             per_minute: 1,
-            erl_activation_period_mins: 20,
-          }
+          })
+
+          await takeElevatedPromise({
+            type: bucketName,
+            key: 'some_bucket_key',
+            erlIsActiveKey: "some-key",
+            allowERL: true
+          }).then((result) => {
+            assert.isTrue(result.conformant);
+            assert.notExists(result.erl_activated);
+          });
+          await takeElevatedPromise({
+            type: bucketName,
+            key: 'some_bucket_key',
+            erlIsActiveKey: undefined
+          }).then((result) => {
+            assert.isTrue(result.conformant);
+            assert.notExists(result.erl_activated);
+          });
         });
-        takeElevatedPromise({type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier'})
-            .then(() => takeElevatedPromise({
-              type: bucketName,
-              key: 'some_key',
-              erlIsActiveKey: 'some_erl_active_identifier'
-            }))
-            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-              assert.equal(ttl, 1200); // 20 minutes in seconds
-              done()
-            }))
+        it('should apply erl limits if normal rate limits are exceeded', async () => {
+          const bucketName = 'bucket_with_elevated_limits_config';
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 10,
+              per_minute: 2,
+            },
+          })
+          const params = {
+            type: bucketName,
+            key: 'some_bucket_key',
+            erlIsActiveKey: 'some_erl_active_identifier',
+            allowERL: true,
+          }
+
+          // first call, still within normal rate limits
+          await takeElevatedPromise(params).then((result) => {
+            assert.isFalse(result.erl_activated);
+          })
+          // second call, normal rate limits exceeded and erl is activated
+          await takeElevatedPromise(params).then((result) => {
+            assert.isTrue(result.erl_activated);
+            assert.isTrue(result.conformant);
+            assert.equal(result.remaining, 8)
+          })
+
+        });
+        it('should rate limit if both normal and erl rate limit are exceeded', async () => {
+          const bucketName = 'bucket_with_elevated_limits_config';
+          const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true,}
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 2,
+              per_minute: 2,
+            },
+          })
+
+          // first call, still within normal rate limits
+          await takeElevatedPromise(params).then((result) => {
+            assert.isTrue(result.conformant);
+            assert.isFalse(result.erl_activated);
+            assert.equal(result.remaining, 0)
+          })
+          // second call, normal rate limits exceeded and erl is activated.
+          // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
+          await takeElevatedPromise(params).then((result) => {
+            assert.isTrue(result.conformant);
+            assert.isTrue(result.erl_activated);
+            assert.equal(result.remaining, 0);
+          })
+          // third call, erl rate limit exceeded
+          await takeElevatedPromise(params).then((result) => {
+            assert.isFalse(result.conformant); // being rate limited
+            assert.isTrue(result.erl_activated);
+            assert.equal(result.remaining, 0);
+          })
+        });
+        it('should deduct already used tokens from new bucket when erl is activated', async () => {
+          const bucketName = 'test-bucket';
+          const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true}
+          await db.configurateBucket(bucketName, {
+            size: 2,
+            per_minute: 1,
+            elevated_limits: {
+              size: 10,
+              per_minute: 1,
+            }
+          });
+
+          await takeElevatedPromise(params)
+          await takeElevatedPromise(params)
+          await takeElevatedPromise(params).then((result) => {
+            assert.isTrue(result.conformant);
+            assert.isTrue(result.erl_activated);
+            assert.equal(result.remaining, 7); // Total used tokens so far: 3
+          });
+        })
+        it('should use default ttl if erl activation period is not configured', (done) => {
+          const bucketName = 'test-bucket';
+          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 10,
+              per_minute: 1,
+            }
+          });
+          takeElevatedPromise(params)
+              .then(() => takeElevatedPromise(params))
+              .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+                assert.equal(ttl, 60*ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES); // 15 minutes in seconds
+                done()
+              }))
+        });
+        it('should use ttl calculated using erl activation period if erl activation period is configured', (done) => {
+          const bucketName = 'test-bucket';
+          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 10,
+              per_minute: 1,
+              erl_activation_period_mins: 20,
+            }
+          });
+          takeElevatedPromise(params)
+              .then(() => takeElevatedPromise(params))
+              .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+                assert.equal(ttl, 1200); // 20 minutes in seconds
+                done()
+              }))
+        });
+        it('should refill with erl refill rate when erl is active', (done) => {
+          const bucketName = 'test-bucket';
+          const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL:true};
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 5,
+              per_interval: 1,
+              interval: 10,
+            }
+          });
+          takeElevatedPromise(params)
+              .then(() => takeElevatedPromise(params)) // erl activated
+              .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
+              .then(() => takeElevatedPromise(params)) // refill with erl refill rate
+              .then((result) => {
+                assert.isTrue(result.conformant);
+                assert.isTrue(result.erl_activated);
+                assert.equal(result.remaining, 3);
+                done();
+              })
+        });
       });
-      it('should refill with erl refill rate when erl is active', (done) => {
-        const bucketName = 'test-bucket';
-        db.configurateBucket(bucketName, {
-          size: 1,
-          per_minute: 1,
-          elevated_limits: {
-            size: 5,
-            per_interval: 1,
-            interval: 10,
-          }
+      describe('when allowERL is false', () => {
+        it('should use normal rate limits regardless of erl configuration or erlIsActiveKey', async () => {
+          const bucketName = 'bucket_with_elevated_limits_config';
+          const erlIsActiveKey = 'some_erl_active_identifier';
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1,
+            elevated_limits: {
+              size: 2,
+              per_minute: 2,
+            },
+          })
+          const params ={type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:false}
+
+          // erl not activated yet
+          await takeElevatedPromise(params)
+
+          // erl is supposed to be activated, but will not be
+          await takeElevatedPromise(params).then((result) => {
+            assert.isFalse(result.conformant);
+            assert.notExists(result.erl_activated);
+          });
+          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
         });
-        takeElevatedPromise({type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier'})
-            .then(() => takeElevatedPromise({
-              type: bucketName,
-              key: 'some_key ',
-              erlIsActiveKey: 'some_erl_active_identifier'
-            })) // erl activated
-            .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
-            .then(() => takeElevatedPromise({
-              type: bucketName,
-              key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier' // refill with erl refill rate
-            }))
-            .then((result) => {
-              assert.isTrue(result.conformant);
-              assert.isTrue(result.erl_activated);
-              assert.equal(result.remaining, 3);
-              done();
-            })
       });
     });
   });

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -6,7 +6,7 @@ const LimitDB  = require('../lib/db');
 const assert   = require('chai').assert;
 const {Toxiproxy, Toxic} = require('toxiproxy-node-client');
 const crypto  = require('crypto')
-const {ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES} = require("../lib/utils");
+const {ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS} = require("../lib/utils");
 
 const buckets = {
   ip: {
@@ -850,7 +850,7 @@ describe('LimitDBRedis', () => {
           takeElevatedPromise(params)
               .then(() => takeElevatedPromise(params))
               .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-                assert.equal(ttl, 60*ERL_DEFAULT_ACTIVATION_PERIOD_MINUTES); // 15 minutes in seconds
+                assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // 15 minutes in seconds
                 done()
               }))
         });
@@ -863,7 +863,7 @@ describe('LimitDBRedis', () => {
             elevated_limits: {
               size: 10,
               per_minute: 1,
-              erl_activation_period_mins: 20,
+              erl_activation_period_seconds: 1200,
             }
           });
           takeElevatedPromise(params)


### PR DESCRIPTION
This PR implements the core mechanism with following functionality for Elevated Rate Limits (ERL):

- If a bucket does not have ERL configured:
-- The token bucket algorithm works exactly as it used to.
- If a bucket has ERL configured:
-- Whenever the bucket runs out of tokens, ERL is activated.
-- ERL stays active until `erl_activation_period_mins` is expired, then the normal bucket configuration takes effect again.

Out of scope of this PR:
- Quota for ERL 
- Alerting or Reporting
- Event creation upon ERL activation